### PR TITLE
Handle rune positions count safely

### DIFF
--- a/D2Helper/chaosBot/scripts/shopping/clawShop/utils.py
+++ b/D2Helper/chaosBot/scripts/shopping/clawShop/utils.py
@@ -74,7 +74,12 @@ def get_rune_positions(template_folder):
         if filename.lower().endswith(".png"):
             template_path = os.path.join(template_folder, filename)
             rune_name = os.path.splitext(os.path.basename(template_path))[0]
-            grouped_matches, count = count_images_on_screen(template_path)
+            result = count_images_on_screen(template_path)
+            if isinstance(result, tuple) and len(result) == 2:
+                grouped_matches, count = result
+            else:
+                grouped_matches = result if result is not None else []
+                count = len(grouped_matches)
             runes_positions[rune_name] = {'positions': grouped_matches, 'count': count}
     return runes_positions
 

--- a/D2Helper/chaosBot/scripts/shopping/gamble/utils.py
+++ b/D2Helper/chaosBot/scripts/shopping/gamble/utils.py
@@ -74,7 +74,12 @@ def get_rune_positions(template_folder):
         if filename.lower().endswith(".png"):
             template_path = os.path.join(template_folder, filename)
             rune_name = os.path.splitext(os.path.basename(template_path))[0]
-            grouped_matches, count = count_images_on_screen(template_path)
+            result = count_images_on_screen(template_path)
+            if isinstance(result, tuple) and len(result) == 2:
+                grouped_matches, count = result
+            else:
+                grouped_matches = result if result is not None else []
+                count = len(grouped_matches)
             runes_positions[rune_name] = {'positions': grouped_matches, 'count': count}
     return runes_positions
 

--- a/D2Helper/utils.py
+++ b/D2Helper/utils.py
@@ -73,7 +73,12 @@ def get_rune_positions(template_folder):
         if filename.lower().endswith(".png"):
             template_path = os.path.join(template_folder, filename)
             rune_name = os.path.splitext(os.path.basename(template_path))[0]
-            grouped_matches, count = count_images_on_screen(template_path)
+            result = count_images_on_screen(template_path)
+            if isinstance(result, tuple) and len(result) == 2:
+                grouped_matches, count = result
+            else:
+                grouped_matches = result if result is not None else []
+                count = len(grouped_matches)
             runes_positions[rune_name] = {'positions': grouped_matches, 'count': count}
     return runes_positions
 


### PR DESCRIPTION
## Summary
- derive rune counts defensively when building rune positions so count_images_on_screen return types no longer cause unpack errors
- apply the same fix across rune helper utility variants

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927827a12408325a8fbbc1197819422)