### PR TITLE
Add pytesseract import to utils

### DIFF
--- a/D2Helper/utils.py
+++ b/D2Helper/utils.py
@@ -8,6 +8,7 @@ import pyautogui
 import time
 import os
 import re
+import pytesseract
 
 # Global variables
 global_x = 0


### PR DESCRIPTION
## Summary
- add the missing pytesseract import in utils so extract_text_from_image can call the library
- ensure pytesseract dependency is listed in requirements

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927830fefb88325a5392d2ef28f268c)